### PR TITLE
Add a callback based pick_one variant

### DIFF
--- a/lua/jdtls.lua
+++ b/lua/jdtls.lua
@@ -429,27 +429,33 @@ function M.code_action(from_selection, kind)
       print("No code actions available")
       return
     end
-    local action = ui.pick_one(actions, 'Code Actions:', function(x)
-      return (x.title:gsub('\r\n', '\\r\\n')):gsub('\n', '\\n')
-    end)
-    if not action then
-      return
-    end
-    if action.edit then
-      vim.lsp.util.apply_workspace_edit(action.edit)
-    end
-    local command
-    if type(action.command) == "table" then
-      command = action.command
-    else
-      command = action
-    end
-    local fn = M.commands[command.command]
-    if fn then
-      fn(command, code_action_params)
-    else
-      M.execute_command(command)
-    end
+    ui.pick_one_async(
+      actions,
+      'Code Actions:',
+      function(x)
+        return (x.title:gsub('\r\n', '\\r\\n')):gsub('\n', '\\n')
+      end,
+      function(action)
+        if not action then
+          return
+        end
+        if action.edit then
+          vim.lsp.util.apply_workspace_edit(action.edit)
+        end
+        local command
+        if type(action.command) == "table" then
+          command = action.command
+        else
+          command = action
+        end
+        local fn = M.commands[command.command]
+        if fn then
+          fn(command, code_action_params)
+        else
+          M.execute_command(command)
+        end
+      end
+    )
   end)
 end
 

--- a/lua/jdtls/ui.lua
+++ b/lua/jdtls/ui.lua
@@ -1,6 +1,12 @@
 local M = {}
 
 
+function M.pick_one_async(items, prompt, label_fn, cb)
+  local result = M.pick_one(items, prompt, label_fn)
+  cb(result)
+end
+
+
 function M.pick_one(items, prompt, label_fn)
   local choices = {prompt}
   for i, item in ipairs(items) do


### PR DESCRIPTION
This will allow users to replace the pick_one method with a popup based
one.

    require('jdtls.ui').pick_one_async = your_implementation

This could be used to display the code action selection in a popup like here:

![image](https://user-images.githubusercontent.com/38700/96038377-537c2f80-0e67-11eb-94e2-7bb003852d78.png)
