### PR TITLE
Add infer selection support for extractMethod

### DIFF
--- a/lua/jdtls/setup.lua
+++ b/lua/jdtls/setup.lua
@@ -45,6 +45,7 @@ local extendedClientCapabilities = {
   advancedOrganizeImportsSupport = true;
   generateConstructorsPromptSupport = true;
   generateDelegateMethodsPromptSupport = true;
+  inferSelectionSupport = {"extractMethod"};
 };
 
 


### PR DESCRIPTION
Requires https://github.com/eclipse/eclipse.jdt.ls/pull/1585


`extract_method` now prompts for choices if there is no clear candidate.

![asciinema-f600e7447e5545d6asciicast](https://user-images.githubusercontent.com/38700/99113205-200bfc80-25ef-11eb-84fd-e17173de4330.gif)
