### PR TITLE
Add support for passing settings to the server

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ following:
 if has('nvim-0.5')
   packadd nvim-jdtls
   lua jdtls = require('jdtls')
-  lua config = {cmd = {'java-lsp.sh'}}
+  lua config = {cmd = {'java-lsp.sh'}, settings = {...}}
   augroup lsp
     au!
     au FileType java lua jdtls.start_or_attach(config)
@@ -113,7 +113,23 @@ endif
 
 The argument passed to `start_or_attach` is the same `config` mentioned in
 `:help vim.lsp.start_client`. You may want to configure some settings via the `init_options`. See the [eclipse.jdt.ls Wiki][8] for an overview of available options.
+Some additional settings can be passed on to the server upon initialization using a
+`workspace/didChangeConfiguration` notification e.g.
 
+```
+lua <<EOF
+  config {
+    cmd = { ... },
+    settings = {
+      ["java.format.settings.url"] = "/path/to/eclipse-style.xml",
+      ["java.format.settings.profile"] = "MyProfile"
+    }
+  }
+EOF
+```
+Possible settings can be seen [here][10] under configuration properties.
+
+**Note**: Exactly which preferences can be configured through this notification is unclear at the moment and your mileage may vary. 
 
 **Warning**: Using [nvim-lspconfig][9] in addition to the setup here is not
 required.
@@ -300,3 +316,4 @@ Try wiping your workspace folder and restart Neovim and the language server.
 [7]: https://github.com/microsoft/vscode-java-test
 [8]: https://github.com/eclipse/eclipse.jdt.ls/wiki/Running-the-JAVA-LS-server-from-the-command-line
 [9]: https://github.com/neovim/nvim-lspconfig
+[10]: https://github.com/redhat-developer/vscode-java/blob/master/package.json

--- a/lua/jdtls/setup.lua
+++ b/lua/jdtls/setup.lua
@@ -90,6 +90,23 @@ local function start_or_attach(config)
           };
       };
   }
+
+  -- Allow settings to be passed to the server
+  config.on_init = function(client, _result)
+      function client.workspace_did_change_configuration(settings)
+          if not settings then return end    -- nil
+          if vim.tbl_isempty(settings) then  -- empty
+              settings = {[vim.type_idx]=vim.types.dictionary}
+          end
+          return client.notify('workspace/didChangeConfiguration', {
+              settings = settings
+          })
+      end
+      if not vim.tbl_isempty(config.settings) then
+          client.workspace_did_change_configuration(config.settings)
+      end
+  end
+
   config.init_options = config.init_options or {}
   config.init_options.extendedClientCapabilities = (
     config.init_options.extendedClientCapabilities or extendedClientCapabilities


### PR DESCRIPTION
Settings can be passed to the server through
`workspace/didChangeConfiguration` notifications:

https://github.com/eclipse/eclipse.jdt.ls/issues/1131
https://github.com/eclipse/eclipse.jdt.ls/issues/1581

It is not clear if all or only some settings can be configured this way
but I have tried setting the `java.format.settings.url` and
`java.format.settings.profile` with success. It is possible that all
configuration properties in
https://github.com/redhat-developer/vscode-java/blob/master/package.json
are supported.

The code is adapted from nvim-lspconfig and sends a notification once on
initialization of the server. But I have very little experience with
both LSP and Lua so this may have to be tweaked for a more general
solution.