### PR TITLE
Add infer selection support for extract_variable

### DIFF
--- a/lua/jdtls/setup.lua
+++ b/lua/jdtls/setup.lua
@@ -45,7 +45,7 @@ local extendedClientCapabilities = {
   advancedOrganizeImportsSupport = true;
   generateConstructorsPromptSupport = true;
   generateDelegateMethodsPromptSupport = true;
-  inferSelectionSupport = {"extractMethod"};
+  inferSelectionSupport = {"extractMethod", "extractVariable"};
 };
 
 


### PR DESCRIPTION
Requires https://github.com/eclipse/eclipse.jdt.ls/pull/1619

Makes `require('jdtls').extract_variable()` prompt for a selection if there are multiple candidates for extraction.


![asciinema-931c83387300850easciicast](https://user-images.githubusercontent.com/38700/100937660-9bc4df00-34f3-11eb-903e-0c6189e589ac.gif)
