### PR TITLE
Fix extract variable / infer selection handling if there is only 1 option

### DIFF
--- a/lua/jdtls.lua
+++ b/lua/jdtls.lua
@@ -225,7 +225,7 @@ local function java_apply_refactoring_command(command, code_action_params)
       return
     end
     if #selection_info == 1 then
-      params.commandArguments = {selection_info}
+      params.commandArguments = selection_info
       request(0, 'java/getRefactorEdit', params, handle_refactor_workspace_edit)
     else
       ui.pick_one_async(


### PR DESCRIPTION
The params send to the server were in an incorrect format, leading to an
error on the server side and on the client nothing happened.

    com.google.gson.JsonSyntaxException: java.lang.IllegalStateException: Expected BEGIN_OBJECT but was BEGIN_ARRAY at path $