### PR TITLE
Make organize imports use the extended version

### DIFF
--- a/lua/jdtls.lua
+++ b/lua/jdtls.lua
@@ -513,10 +513,7 @@ end
 
 
 function M.organize_imports()
-  M.execute_command({
-    command = "java.edit.organizeImports";
-    arguments = { vim.uri_from_bufnr(0) }
-  })
+  java_action_organize_imports(nil, make_code_action_params(false))
 end
 
 


### PR DESCRIPTION
`require('jdtls').organize_imports()` used the simple organize import
version which didn't prompt the user to select the exact import in case
of ambiguous choices.

This changes it so that it behaves the same as if the user selected the
`Organize import` option via code action.