### PR TITLE
Extend test functions

### DIFF
--- a/lua/jdtls.lua
+++ b/lua/jdtls.lua
@@ -1,4 +1,3 @@
-local M = {}
 local api = vim.api
 
 local ui = require('jdtls.ui')
@@ -8,18 +7,23 @@ local with_java_executable = util.with_java_executable
 local resolve_classname = util.resolve_classname
 local execute_command = util.execute_command
 
-for i, v in pairs(require('jdtls.dap')) do
-  M[i] = v
-end
+local jdtls_dap = require('jdtls.dap')
+local setup = require('jdtls.setup')
+
+local M = {
+  setup_dap = jdtls_dap.setup_dap,
+  test_class = jdtls_dap.test_class,
+  test_nearest_method = jdtls_dap.test_nearest_method,
+  pick_test = jdtls_dap.pick_test,
+  extendedClientCapabilities = setup.extendedClientCapabilities,
+  start_or_attach = setup.start_or_attach,
+  setup = setup,
+}
 
 local request = vim.lsp.buf_request
 local highlight_ns = api.nvim_create_namespace('jdtls_hl')
 M.jol_path = nil
 
-local setup = require('jdtls.setup')
-M.extendedClientCapabilities = setup.extendedClientCapabilities
-M.start_or_attach = setup.start_or_attach
-M.setup = setup
 
 
 local function java_apply_workspace_edit(command)

--- a/lua/jdtls/dap.lua
+++ b/lua/jdtls/dap.lua
@@ -229,6 +229,16 @@ local function run(lens, config, context, opts)
 end
 
 
+--- API of these methods is unstable and might change in the future
+M.experimental = {
+  run = run,
+  fetch_lenses = fetch_lenses,
+  fetch_launch_args = fetch_launch_args,
+  make_context = make_context,
+  make_config = make_config,
+}
+
+
 function M.test_class(opts)
   opts = opts or {}
   local context = make_context()

--- a/lua/jdtls/dap.lua
+++ b/lua/jdtls/dap.lua
@@ -264,6 +264,28 @@ function M.test_nearest_method(opts)
 end
 
 
+function M.pick_test(opts)
+  opts = opts or {}
+  local context = make_context()
+  fetch_lenses(context, function(lenses)
+    require('jdtls.ui').pick_one_async(
+      lenses,
+      'Tests> ',
+      function(lens) return lens.fullName end,
+      function(lens)
+        if not lens then
+          return
+        end
+        fetch_launch_args(lens, context, function(launch_args)
+          local config = make_config(lens, launch_args)
+          run(lens, config, context, opts)
+        end)
+      end
+    )
+  end)
+end
+
+
 local original_configurations = nil
 function M.setup_dap()
   local status, dap = pcall(require, 'dap')

--- a/lua/jdtls/dap.lua
+++ b/lua/jdtls/dap.lua
@@ -195,12 +195,13 @@ local function make_context()
 end
 
 
-local function run(lens, config, context)
+local function run(lens, config, context, opts)
   local ok, dap = pcall(require, 'dap')
   if not ok then
     vim.notify('`nvim-dap` must be installed to run and debug methods')
     return
   end
+  config = vim.tbl_extend('force', config, opts.config or {})
   local test_results
   local server = nil
   local junit = require('jdtls.junit')
@@ -228,7 +229,8 @@ local function run(lens, config, context)
 end
 
 
-function M.test_class()
+function M.test_class(opts)
+  opts = opts or {}
   local context = make_context()
   fetch_lenses(context, function(lenses)
     local lens = get_first_class_lens(lenses)
@@ -238,13 +240,14 @@ function M.test_class()
     end
     fetch_launch_args(lens, context, function(launch_args)
       local config = make_config(lens, launch_args)
-      run(lens, config, context)
+      run(lens, config, context, opts)
     end)
   end)
 end
 
 
-function M.test_nearest_method()
+function M.test_nearest_method(opts)
+  opts = opts or {}
   local lnum = api.nvim_win_get_cursor(0)[1]
   local context = make_context()
   fetch_lenses(context, function(lenses)
@@ -255,7 +258,7 @@ function M.test_nearest_method()
     end
     fetch_launch_args(lens, context, function(launch_args)
       local config = make_config(lens, launch_args)
-      run(lens, config, context)
+      run(lens, config, context, opts)
     end)
   end)
 end


### PR DESCRIPTION
- Add a `pick_test` method that prompts which test to run
- Add a `opts` argument to test methods to allow config override

   For example, to use the dap-repl for output instead of the terminal:

       test_nearest_method({ config = { console = 'console' }})