### PR TITLE
Add an option to run tests repeatedly until error or limit

### DIFF
--- a/lua/jdtls/junit.lua
+++ b/lua/jdtls/junit.lua
@@ -114,6 +114,7 @@ function M.mk_test_results(bufnr)
       else
         print('Tests finished. Results printed to dap-repl. All', #tests, 'succeeded')
       end
+      return items
     end;
     mk_reader = function(sock)
       return vim.schedule_wrap(mk_buf_loop(sock, handle_buffer))


### PR DESCRIPTION
```
:lua require('jdtls').test_nearest_method { until_error = 10 }
```


https://user-images.githubusercontent.com/38700/111486733-082cbc80-8738-11eb-9c0f-91b46dc4ac00.mp4

