### PR TITLE
Revert "Add workaround for `buffer ... newer than edits`"

### DIFF
--- a/lua/jdtls.lua
+++ b/lua/jdtls.lua
@@ -33,7 +33,7 @@ M.jol_path = nil
 
 local function java_apply_workspace_edit(command)
   for _, argument in ipairs(command.arguments) do
-    util.apply_workspace_edit(argument)
+    vim.lsp.util.apply_workspace_edit(argument)
   end
 end
 
@@ -64,7 +64,7 @@ local function java_generate_to_string_prompt(_, params)
         return
       end
       if edit then
-        util.apply_workspace_edit(edit)
+        vim.lsp.util.apply_workspace_edit(edit)
       end
     end)
   end)
@@ -109,7 +109,7 @@ local function java_generate_constructors_prompt(_, code_action_params)
       if err1 then
         print("Could not execute java/generateConstructors: " .. err1.message)
       elseif edit then
-        util.apply_workspace_edit(edit)
+        vim.lsp.util.apply_workspace_edit(edit)
       end
     end)
   end)
@@ -163,7 +163,7 @@ local function java_generate_delegate_methods_prompt(_, code_action_params)
       if err1 then
         print('Could not execute java/generateDelegateMethods', err1.message)
       elseif workspace_edit then
-        util.apply_workspace_edit(workspace_edit)
+        vim.lsp.util.apply_workspace_edit(workspace_edit)
       end
     end)
   end)
@@ -184,7 +184,7 @@ local function java_hash_code_equals_prompt(_, params)
         print("Could not execute java/generateHashCodeEquals: " .. e.message)
       end
       if edit then
-        util.apply_workspace_edit(edit)
+        vim.lsp.util.apply_workspace_edit(edit)
       end
     end)
   end)
@@ -201,7 +201,7 @@ local function handle_refactor_workspace_edit(err, _, result)
   end
 
   if result.edit then
-    util.apply_workspace_edit(result.edit)
+    vim.lsp.util.apply_workspace_edit(result.edit)
   end
 
   if result.command then
@@ -463,7 +463,7 @@ local function java_action_organize_imports(_, code_action_params)
       return
     end
     if resp then
-      util.apply_workspace_edit(resp)
+      vim.lsp.util.apply_workspace_edit(resp)
     end
   end)
 end
@@ -665,7 +665,7 @@ function M.code_action(from_selection, kind)
           return
         end
         if action.edit then
-          util.apply_workspace_edit(action.edit)
+          vim.lsp.util.apply_workspace_edit(action.edit)
         end
         local command
         if type(action.command) == "table" then

--- a/lua/jdtls/util.lua
+++ b/lua/jdtls/util.lua
@@ -3,30 +3,6 @@ local request = vim.lsp.buf_request
 local M = {}
 
 
---- Takes a workspaceEdit and nils versions of textDocuments within the
---- documentChanges if the version is zero.
----
---- Workaround for https://github.com/eclipse/eclipse.jdt.ls/issues/1695
---- Will be removed once it is no longer necessary
-function M._nil_version_if_zero(edit)
-  if not edit or not edit.documentChanges then
-    return edit
-  end
-  for _, change in pairs(edit.documentChanges) do
-    local text_document = change.textDocument
-    if text_document and text_document.version and text_document.version == 0 then
-      text_document.version = nil
-    end
-  end
-  return edit
-end
-
-
-function M.apply_workspace_edit(edit)
-  return vim.lsp.util.apply_workspace_edit(M._nil_version_if_zero(edit))
-end
-
-
 function M.execute_command(command, callback)
   request(0, 'workspace/executeCommand', command, function(err, _, resp)
     if callback then


### PR DESCRIPTION
Neovim now accepts version 0 in text document edits.
See https://github.com/neovim/neovim/pull/14366

This reverts commit ca5154f57df45230a3c4aa3b67cc49c516299edf.