### PR TITLE
Support hotcode replacement via nvim-dap

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,10 @@ To do that, extend the configuration for `nvim-jdtls` with:
 
 ```lua
 config['on_attach'] = function(client, bufnr)
-  require('jdtls').setup_dap()
+  -- With `hotcodereplace = 'auto' the debug adapter will try to apply code changes
+  -- you make during a debug session immediately.
+  -- Remove the option if you do not want that.
+  require('jdtls').setup_dap({ hotcodereplace = 'auto' })
 end
 ```
 


### PR DESCRIPTION
Calling `setup_dap` with `{ hotcodereplace = 'auto' }` will enable
hotcode reloading during an active debugging session.

There are some limitations - for example, the current active stackframe
cannot be modified.

Requires https://github.com/mfussenegger/nvim-dap/pull/179