### PR TITLE
Add JdtCompile argument completion/change arg to full/incremental

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ If it doesn't, verify:
 
 2. Eclipse.jdt.ls can't compile your project or it cannot load your project and resolve the class paths.
 
-- Run `:JdtCompile` for incremental compilation or `:JdtCompile true` for full
+- Run `:JdtCompile` for incremental compilation or `:JdtCompile full` for full
   compilation. If there are any errors in the project, it will open the
   quickfix list with the errors.
 

--- a/lua/jdtls.lua
+++ b/lua/jdtls.lua
@@ -707,14 +707,19 @@ function M.organize_imports()
 end
 
 
-function M.compile(full_compile)
+function M._complete_compile()
+  return 'full\nincremental'
+end
+
+
+function M.compile(type)
   local CompileWorkspaceStatus = {
     FAILED = 0,
     SUCCEED = 1,
     WITHERROR = 2,
     CANCELLED = 3,
   }
-  request(0, 'java/buildWorkspace', full_compile or false, function(err, _, result)
+  request(0, 'java/buildWorkspace', type == 'full', function(err, _, result)
     assert(not err, 'Error on `java/buildWorkspace`: ' .. vim.inspect(err))
     if result == CompileWorkspaceStatus.SUCCEED then
       print('Compile successfull')
@@ -758,7 +763,6 @@ function M.compile(full_compile)
     end
   end)
 end
-
 
 function M.update_project_config()
   local params = { uri = vim.uri_from_bufnr(0) }

--- a/lua/jdtls/setup.lua
+++ b/lua/jdtls/setup.lua
@@ -209,7 +209,7 @@ end
 
 
 function M.add_commands()
-  api.nvim_command [[command! -buffer -nargs=? JdtCompile lua require('jdtls').compile(<f-args>)]]
+  api.nvim_command [[command! -buffer -nargs=? -complete=custom,v:lua.require'jdtls'._complete_compile JdtCompile lua require('jdtls').compile(<f-args>)]]
   api.nvim_command [[command! -buffer JdtUpdateConfig lua require('jdtls').update_project_config()]]
   api.nvim_command [[command! -buffer -nargs=* JdtJol lua require('jdtls').jol(<f-args>)]]
   api.nvim_command [[command! -buffer JdtBytecode lua require('jdtls').javap()]]


### PR DESCRIPTION
Something must have changed in eclipse.jdt.ls: Using a `'true'`
value as argument to `java/buildWorkspace` no longer triggered full
compilation.

This uses this as an opportunity to change the argument to `full` or
`incremental` and to add completion for the two options.