### PR TITLE
Don't require projectName for dap configs

### DIFF
--- a/lua/jdtls/dap.lua
+++ b/lua/jdtls/dap.lua
@@ -30,7 +30,7 @@ local function enrich_dap_config(config_, on_config)
         end
       end
     end
-    assert(config.projectName, "projectName is missing")
+    config.projectName = config.projectName or ''
     with_java_executable(config.mainClass, config.projectName, function(java_exec)
       config.javaExec = config.javaExec or java_exec
       local params = {


### PR DESCRIPTION
The proejctName is only requires for multi module projects.
