### PR TITLE
Fix error due to possible nil value.

### DIFF
--- a/lua/jdtls/dap.lua
+++ b/lua/jdtls/dap.lua
@@ -421,7 +421,7 @@ function M.setup_dap_main_class_configs()
     return
   end
   if not orig_configurations then
-    orig_configurations = vim.deepcopy(dap.configurations.java)
+    orig_configurations = vim.deepcopy(dap.configurations.java) or {}
   end
   local current_configurations = vim.deepcopy(orig_configurations)
   M.fetch_main_configs(function(configurations)


### PR DESCRIPTION
`orig_configurations`  can be `nil` if there are no java configurations.