### PR TITLE
Improve jshell

### DIFF
--- a/lua/jdtls.lua
+++ b/lua/jdtls.lua
@@ -836,7 +836,7 @@ function M.jshell()
     with_java_executable(resolve_classname(), '', function(java_exec)
       api.nvim_win_set_buf(0, buf)
       local jshell = vim.fn.fnamemodify(java_exec, ':h') .. '/jshell'
-      vim.fn.termopen({jshell, '--class-path', cp})
+      vim.fn.termopen(jshell, { env = { ["CLASSPATH"] = cp }})
     end)
   end)
 end

--- a/lua/jdtls/util.lua
+++ b/lua/jdtls/util.lua
@@ -35,7 +35,7 @@ function M.resolve_classname()
   local lines = api.nvim_buf_get_lines(0, 0, -1, true)
   local pkgname
   for _, line in ipairs(lines) do
-    local match = line:match('package ([a-z\\.]+);')
+    local match = line:match('package ([a-z0-9_\\.]+);')
     if match then
       pkgname = match
       break


### PR DESCRIPTION
Package names can also include digits and underscores according to the Oracle documentation:
https://docs.oracle.com/javase/tutorial/java/package/namingpkgs.html

This did actually prevented me from starting a JShell for a project with a package name like `com.some_company.service.v2` (just an example)

Also I propose to set the classpath for the JShell as environment variable rather than using the `--classpath` option as they otherwise do not appear for the tab completion (for some JDKs), see:
https://bugs.openjdk.java.net/browse/JDK-8177650
https://advancedweb.hu/using-external-libraries-in-jshell/

I am using this custom branch at work for a few days now and didn't have any problems so far