### PR TITLE
Fix error in implicit save on empty buffer

### DIFF
--- a/lua/jdtls/setup.lua
+++ b/lua/jdtls/setup.lua
@@ -164,7 +164,11 @@ local function maybe_implicit_save()
     if scheme ~= 'file' then
       return
     end
-    local stat = vim.loop.fs_stat(api.nvim_buf_get_name(bufnr))
+    local fname = api.nvim_buf_get_name(bufnr)
+    if fname == '' then
+      return
+    end
+    local stat = vim.loop.fs_stat(fname)
     if not stat then
       vim.fn.mkdir(vim.fn.expand('%:p:h'), 'p')
       vim.cmd('w')


### PR DESCRIPTION
If you open up neovim and run `:set ft=java` there is no file name

Fixes https://github.com/mfussenegger/nvim-jdtls/issues/109
