### PR TITLE
Fix nil progress message

### DIFF
--- a/lua/jdtls/setup.lua
+++ b/lua/jdtls/setup.lua
@@ -7,7 +7,7 @@ local M = {}
 local URI_SCHEME_PATTERN = '^([a-zA-Z]+[a-zA-Z0-9+-.]*)://.*'
 
 
-local status_callback = vim.schedule_wrap(util.mk_handler(function(_, result)
+local status_callback = vim.schedule_wrap(util.mk_handler(function(_, _, result)
   api.nvim_command(string.format(':echohl Function | echo "%s" | echohl None', result.message))
 end))
 


### PR DESCRIPTION
Fixed the start status (nil value). Apparently, it was necessary to create a new placeholder in the callback received by the util.mk_handler() function, as it was trying to index the "message" attribute to the wrong element (it skipped the table containing the message, and tried to index the attribute to the "language/state" string).

Before:

![image](https://user-images.githubusercontent.com/65829671/132632117-9fd089a2-7202-484a-a006-cd39eef84777.png)

After:

![image](https://user-images.githubusercontent.com/65829671/132632181-f64d4965-6ecd-4aac-b365-15e2e6bec556.png)
