### PR TITLE
Remove arg count check in lsp-handler compat shim

### DIFF
--- a/lua/jdtls/util.lua
+++ b/lua/jdtls/util.lua
@@ -4,9 +4,8 @@ local M = {}
 
 function M.mk_handler(fn)
   return function(...)
-    local count = select('#', ...)
     local config_or_client_id = select(4, ...)
-    local is_new = type(config_or_client_id) ~= 'number' or count == 4
+    local is_new = type(config_or_client_id) ~= 'number'
     if is_new then
       return fn(...)
     else


### PR DESCRIPTION
`language/status` is called via the notification dispatch mechanism,
which is also called with 4 arguments in nvim 0.5.

Fixes https://github.com/mfussenegger/nvim-jdtls/issues/134
