### PR TITLE
Prevent "No LSP client found that supports" errors on buffer switch

### DIFF
--- a/lua/jdtls/dap.lua
+++ b/lua/jdtls/dap.lua
@@ -19,6 +19,7 @@ local function enrich_dap_config(config_, on_config)
   if not config.mainClass then
     config.mainClass = resolve_classname()
   end
+  local bufnr = api.nvim_get_current_buf()
   util.execute_command({command = 'vscode.java.resolveMainClass'}, function(err, mainclasses)
     assert(not err, err and (err.message or vim.inspect(err)))
 
@@ -47,9 +48,9 @@ local function enrich_dap_config(config_, on_config)
           paths[2]
         )
         on_config(config)
-      end)
-    end)
-  end)
+      end, bufnr)
+    end, bufnr)
+  end, bufnr)
 end
 
 
@@ -218,9 +219,9 @@ local function fetch_launch_args(lens, context, on_launch_args)
         assert(not err1, vim.inspect(err1))
         launch_args.classpath = merge_unique(launch_args.classpath, resp.classpaths)
         on_launch_args(launch_args)
-      end)
+      end, context.bufnr)
     end
-  end)
+  end, context.bufnr)
 end
 
 
@@ -435,6 +436,7 @@ local hotcodereplace_type = {
 
 function M.fetch_main_configs(callback)
   local configurations = {}
+  local bufnr = api.nvim_get_current_buf()
   util.execute_command({command = 'vscode.java.resolveMainClass'}, function(err, mainclasses)
     assert(not err, vim.inspect(err))
 
@@ -468,10 +470,10 @@ function M.fetch_main_configs(callback)
           if remaining == 0 then
             callback(configurations)
           end
-        end)
-      end)
+        end, bufnr)
+      end, bufnr)
     end
-  end)
+  end, bufnr)
 end
 
 local orig_configurations

--- a/lua/jdtls/util.lua
+++ b/lua/jdtls/util.lua
@@ -21,9 +21,9 @@ function M.mk_handler(fn)
 end
 
 
-function M.execute_command(command, callback)
+function M.execute_command(command, callback, bufnr)
   local clients = {}
-  for _, c in pairs(vim.lsp.buf_get_clients()) do
+  for _, c in pairs(vim.lsp.buf_get_clients(bufnr)) do
     local command_provider = c.server_capabilities.executeCommandProvider
     local commands = type(command_provider) == 'table' and command_provider.commands or {}
     if vim.tbl_contains(commands, command.command) then
@@ -52,7 +52,7 @@ function M.execute_command(command, callback)
 end
 
 
-function M.with_java_executable(mainclass, project, fn)
+function M.with_java_executable(mainclass, project, fn, bufnr)
   vim.validate({
     mainclass = { mainclass, 'string' }
   })
@@ -65,7 +65,7 @@ function M.with_java_executable(mainclass, project, fn)
     else
       fn(java_exec)
     end
-  end)
+  end, bufnr)
 end
 
 


### PR DESCRIPTION
Fixes a race where if you invoke an action like running a test class and
then switching to a non-java buffer could lead to a "No LSP client found
that supports" error.
