### PR TITLE
Remove nvim 0.5.0 compatibility layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # nvim-jdtls
 
-Extensions for the built-in [Language Server Protocol][1] support in [Neovim][2] (>= 0.5) for [eclipse.jdt.ls][3].
+Extensions for the built-in [Language Server Protocol][1] support in [Neovim][2] (>= 0.5.1) for [eclipse.jdt.ls][3].
 
 ## Extensions
 
@@ -28,7 +28,7 @@ see some of the functionality in action.
 
 ## Plugin Installation
 
-- Requires Neovim (>= 0.5)
+- Requires Neovim (>= 0.5.1)
 - nvim-jdtls is a plugin. Install it like any other Vim plugin:
   - If using [vim-plug][14]: `Plug 'mfussenegger/nvim-jdtls'`
   - If using [packer.nvim][15]: `use 'mfussenegger/nvim-jdtls'`

--- a/lua/jdtls.lua
+++ b/lua/jdtls.lua
@@ -26,7 +26,7 @@ local M = {
 }
 
 local request = function(bufnr, method, params, handler)
-  vim.lsp.buf_request(bufnr, method, params, util.mk_handler(handler))
+  vim.lsp.buf_request(bufnr, method, params, handler)
 end
 local highlight_ns = api.nvim_create_namespace('jdtls_hl')
 M.jol_path = nil
@@ -553,7 +553,7 @@ end
 
 
 if not vim.lsp.handlers['workspace/executeClientCommand'] then
-  vim.lsp.handlers['workspace/executeClientCommand'] = util.mk_handler(function(_, params, ctx)  -- luacheck: ignore 122
+  vim.lsp.handlers['workspace/executeClientCommand'] = function(_, params, ctx)  -- luacheck: ignore 122
     local fn = M.commands[params.command]
     if fn then
       local ok, result = pcall(fn, params.arguments, ctx)
@@ -568,7 +568,7 @@ if not vim.lsp.handlers['workspace/executeClientCommand'] then
         'Command ' .. params.command .. ' not supported on client'
       )
     end
-  end)
+  end
 end
 
 local function within_range(outer, inner)
@@ -721,13 +721,13 @@ function M.code_action(from_selection, kind)
         elseif client
             and type(client.resolved_capabilities.code_action) == 'table'
             and client.resolved_capabilities.code_action.resolveProvider then
-          client.request('codeAction/resolve', action, util.mk_handler(function(err1, result)
+          client.request('codeAction/resolve', action, function(err1, result)
             assert(not err1, vim.inspect(err1))
             if result.edit then
               vim.lsp.util.apply_workspace_edit(result.edit)
             end
             apply_command(result, ctx)
-          end), ctx.bufnr)
+          end, ctx.bufnr)
         else
           apply_command(action, ctx)
         end
@@ -916,9 +916,9 @@ function M.open_jdt_link(uri)
     uri = uri
   }
   local response = nil
-  local cb = util.mk_handler(function(err, result)
+  local cb = function(err, result)
     response = {err, result}
-  end)
+  end
   local ok, request_id = client.request('java/classFileContents', params, cb, buf)
   assert(ok, 'Request to `java/classFileContents` must succeed to open JDT URI. Client shutdown?')
   local timeout_ms = M.settings.jdt_uri_timeout_ms

--- a/lua/jdtls/dap.lua
+++ b/lua/jdtls/dap.lua
@@ -184,13 +184,13 @@ local function fetch_candidates(context, on_candidates)
     return
   end
 
-  local handler = util.mk_handler(function(err, result)
+  local handler = function(err, result)
     if err then
       vim.notify('Errror fetching test candidates: ' .. (err.message or vim.inspect(err)), vim.log.levels.ERROR)
     else
       on_candidates(result or {})
     end
-  end)
+  end
   client.request('workspace/executeCommand', params, handler, context.bufnr)
 end
 

--- a/lua/jdtls/util.lua
+++ b/lua/jdtls/util.lua
@@ -2,25 +2,6 @@ local api = vim.api
 local M = {}
 
 
-function M.mk_handler(fn)
-  return function(...)
-    local config_or_client_id = select(4, ...)
-    local is_new = type(config_or_client_id) ~= 'number'
-    if is_new then
-      return fn(...)
-    else
-      local err = select(1, ...)
-      local method = select(2, ...)
-      local result = select(3, ...)
-      local client_id = select(4, ...)
-      local bufnr = select(5, ...)
-      local config = select(6, ...)
-      return fn(err, result, { method = method, client_id = client_id, bufnr = bufnr }, config)
-    end
-  end
-end
-
-
 function M.execute_command(command, callback, bufnr)
   local clients = {}
   for _, c in pairs(vim.lsp.buf_get_clients(bufnr)) do
@@ -42,13 +23,13 @@ function M.execute_command(command, callback, bufnr)
       vim.log.levels.WARN)
   end
 
-  clients[1].request('workspace/executeCommand', command, M.mk_handler(function(err, resp)
+  clients[1].request('workspace/executeCommand', command, function(err, resp)
     if callback then
       callback(err, resp)
     elseif err then
       print("Could not execute code action: " .. err.message)
     end
-  end))
+  end)
 end
 
 


### PR DESCRIPTION
0.5.1 is now the required minimum version

As mentioned in https://github.com/mfussenegger/nvim-jdtls/issues/3#issuecomment-954073931