### PR TITLE
Deprecate custom code_action method

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,12 +196,6 @@ Neovim, so all the functions mentioned in `:help lsp` will work.
 mappings:
 
 ```vimL
--- `code_action` is a superset of vim.lsp.buf.code_action and you'll be able to
--- use this mapping also with other language servers
-nnoremap <A-CR> <Cmd>lua require('jdtls').code_action()<CR>
-vnoremap <A-CR> <Esc><Cmd>lua require('jdtls').code_action(true)<CR>
-nnoremap <leader>r <Cmd>lua require('jdtls').code_action(false, 'refactor')<CR>
-
 nnoremap <A-o> <Cmd>lua require'jdtls'.organize_imports()<CR>
 nnoremap crv <Cmd>lua require('jdtls').extract_variable()<CR>
 vnoremap crv <Esc><Cmd>lua require('jdtls').extract_variable(true)<CR>

--- a/lua/jdtls.lua
+++ b/lua/jdtls.lua
@@ -661,6 +661,11 @@ end
 
 -- Similar to https://github.com/neovim/neovim/pull/11607, but with extensible commands
 function M.code_action(from_selection, kind)
+  if from_selection then
+    vim.notify('jdtls.code_action() is deprecated. You can use vim.lsp.buf.range_code_action in neovim 0.6 for the same functionality')
+  else
+    vim.notify('jdtls.code_action() is deprecated. You can use vim.lsp.buf.code_action in neovim 0.6 for the same functionality')
+  end
   local code_action_params = make_code_action_params(from_selection or false, kind)
   local function apply_command(action, ctx)
     local command


### PR DESCRIPTION
With neovim 0.6 it is possible to use the built-in
vim.lsp.buf.code_action function and still have all extensions from
jdtls work.
