### PR TITLE
Remove some codeAction extra capabilities

### DIFF
--- a/lua/jdtls/setup.lua
+++ b/lua/jdtls/setup.lua
@@ -215,10 +215,6 @@ function M.start_or_attach(config)
   local extra_capabilities = {
     textDocument = {
       codeAction = {
-        dataSupport = true;
-        resolveSupport = {
-          properties = {'edit',}
-        };
         codeActionLiteralSupport = {
           codeActionKind = {
             valueSet = {


### PR DESCRIPTION
These are set by default in neovim since 0.6
