### PR TITLE
Remove workspaceEdit.resourceOperations check

### DIFF
--- a/lua/jdtls/setup.lua
+++ b/lua/jdtls/setup.lua
@@ -238,14 +238,6 @@ function M.start_or_attach(config)
     }
   })
   config.on_init = init_with_config_notify(config.on_init)
-  local workspace = capabilities.workspace or {}
-  if not workspace.workspaceEdit
-    or not vim.tbl_contains(workspace.workspaceEdit.resourceOperations, 'rename')
-    or not vim.tbl_contains(workspace.workspaceEdit.resourceOperations, 'create')
-    or not vim.tbl_contains(workspace.workspaceEdit.resourceOperations, 'delete')
-  then
-    config.init_options.extendedClientCapabilities.moveRefactoringSupport = false;
-  end
   maybe_implicit_save()
   lsp_clients.start(config)
 end


### PR DESCRIPTION
With neovim 0.6 as minimum requirement the
workspaceEdit.resourceOperations support is always there. No need to
protect against it missing anymore.
