### PR TITLE
Add a `after_test` callback to dap test functions

### DIFF
--- a/doc/jdtls.txt
+++ b/doc/jdtls.txt
@@ -171,8 +171,10 @@ JdtTestOpts                                                        *JdtTestOpts*
 
 
     Fields: ~
+        {config}            (nil|table)         Skeleton used for the |dap-configuration|
         {config_overrides}  (nil|JdtDapConfig)  Overrides for the |dap-configuration|, see |JdtDapConfig|
         {until_error}       (number|nil)        Number of times the test should be repeated if it doesn't fail
+        {after_test}        (nil|function)      Callback triggered after test run
 
 
 vim:tw=78:ts=8:noet:ft=help:norl:

--- a/lemmy.sh
+++ b/lemmy.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+lemmy-help lua/jdtls.lua lua/jdtls/dap.lua >doc/jdtls.txt


### PR DESCRIPTION
Closes https://github.com/mfussenegger/nvim-jdtls/issues/264
