### PR TITLE
Bump java requirement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ local config = {
   cmd = {
 
     -- 💀
-    'java', -- or '/path/to/java11_or_newer/bin/java'
+    'java', -- or '/path/to/java17_or_newer/bin/java'
             -- depends on if `java` is in your $PATH env variable and if it points to the right version.
 
     '-Declipse.application=org.eclipse.jdt.ls.core.id1',
@@ -402,7 +402,7 @@ either need to write them out or wrap the fragments in `vim.fn.expand` calls.
 
 ### Unrecognized option: --add-modules=ALL-SYSTEM
 
-Eclipse.jdt.ls requires at least Java 11. You're using a lower version.
+Eclipse.jdt.ls requires at least Java 17. You're using a lower version.
 
 ### is a non-project file, only syntax errors are reported
 


### PR DESCRIPTION
Eclipse.jdt.ls 1.13.0 requires at least Java 17
