### PR TITLE
Adding project name to launch menu entries in order to avoid confusions

### DIFF
--- a/lua/jdtls/dap.lua
+++ b/lua/jdtls/dap.lua
@@ -507,7 +507,7 @@ function M.fetch_main_configs(opts, callback)
             end
             local config = {
               type = 'java';
-              name = 'Launch ' .. mainclass;
+              name = 'Launch ' .. project .. ': ' .. mainclass;
               projectName = project;
               mainClass = mainclass;
               modulePaths = paths[1];

--- a/lua/jdtls/dap.lua
+++ b/lua/jdtls/dap.lua
@@ -507,7 +507,7 @@ function M.fetch_main_configs(opts, callback)
             end
             local config = {
               type = 'java';
-              name = 'Launch ' .. project .. ': ' .. mainclass;
+              name = 'Launch ' .. (project or '') .. ': ' .. mainclass;
               projectName = project;
               mainClass = mainclass;
               modulePaths = paths[1];


### PR DESCRIPTION
Just adding name of the project in the launch menu entries (DAP). I work with several projects at the same time where the launch class is always in the same path and with the same name. I add it just to prevent that the entries of the menu look exactly the same. Not a major change, it is arguable a bad practice but it is a situation that may happen to other users