### PR TITLE
Refactor the setup dap configurations callback

### DIFF
--- a/lua/jdtls/dap.lua
+++ b/lua/jdtls/dap.lua
@@ -559,19 +559,16 @@ function M.setup_dap_main_class_configs(opts)
     vim.notify('Fetching debug configurations')
   end
   M.fetch_main_configs(opts, function(configurations)
-    local configs = {}
+    local dap_configurations = dap.configurations.java or {}
     for _, config in ipairs(configurations) do
-        configs[config.cwd..config.name] = config
+      for i, existing_config in pairs(dap_configurations) do
+        if config.name == existing_config.name and config.cwd == existing_config.cwd then
+          table.remove(dap_configurations, i)
+        end
+      end
+      table.insert(dap_configurations, config)
     end
-    local java_configs = vim.tbl_filter(function(config)
-      -- filter out existing configs which we are about to update
-      return not configs[config.cwd..config.name]
-    end, dap.configurations.java or {})
-    -- add new and updated configurations
-    for _, config in pairs(configs) do
-        table.insert(java_configs, config)
-    end
-    dap.configurations.java = java_configs
+    dap.configurations.java = dap_configurations
     if opts.verbose then
       vim.notify(string.format('Updated %s debug configuration(s)', #configurations))
     end


### PR DESCRIPTION
After your [comment](https://github.com/mfussenegger/nvim-jdtls/pull/369#issuecomment-1330552299) I had another look into the `setup_dap_main_class_configs` callback function and refactored the code. This solution should be easier to understand.

Also I once got an error because the `cwd` of a passed config was `nil` which resulted in an error [here](https://github.com/mfussenegger/nvim-jdtls/blob/master/lua/jdtls/dap.lua#L564) (trying to string concatenate a nil value). I only encountered it one time and could not reproduce the issue, but with the refactored implementation this should not happen anymore since it now uses equality checks instead.