### PR TITLE
Fix extract variable with replace all occurrences

### DIFF
--- a/lua/jdtls/setup.lua
+++ b/lua/jdtls/setup.lua
@@ -128,7 +128,12 @@ M.extendedClientCapabilities = {
   generateDelegateMethodsPromptSupport = true;
   moveRefactoringSupport = true;
   overrideMethodsPromptSupport = true;
-  inferSelectionSupport = {"extractMethod", "extractVariable", "extractConstant"};
+  inferSelectionSupport = {
+    "extractMethod",
+    "extractVariable",
+    "extractConstant",
+    "extractVariableAllOccurrence"
+  };
 };
 
 


### PR DESCRIPTION
Adds extractVariableAllOccurrence to inferSelectionSupport to make the
"Extract to local variable (replace all occurrences)" code action work

Closes https://github.com/mfussenegger/nvim-jdtls/issues/371
