### PR TITLE
Skip JDK and built-in classes when debugging

### DIFF
--- a/lua/jdtls/dap.lua
+++ b/lua/jdtls/dap.lua
@@ -310,6 +310,9 @@ local function make_config(lens, launch_args, config_overrides)
     modulePaths = launch_args.modulepath;
     vmArgs = table.concat(launch_args.vmArguments, ' ');
     noDebug = false;
+    stepFilters = {
+      skipClasses = { '$JDK', 'jdk.*', 'java.*', 'javax.*', 'sun.*', 'sunw.*', 'com.sun.*' };
+    };
   }
   config = vim.tbl_extend('force', config, config_overrides or default_config_overrides)
   if lens.testKind == TestKind.TestNG or lens.kind == TestKind.TestNG then
@@ -535,6 +538,9 @@ function M.fetch_main_configs(opts, callback)
               request = 'launch';
               console = 'integratedTerminal';
               vmArgs = use_preview and '--enable-preview' or nil;
+              stepFilters = {
+                skipClasses = { '$JDK', 'jdk.*', 'java.*', 'javax.*', 'sun.*', 'sunw.*', 'com.sun.*' };
+              };
             }
             config = vim.tbl_extend('force', config, opts.config_overrides or default_config_overrides)
             table.insert(configurations, config)


### PR DESCRIPTION
This PR sets a configuration in debug `launch` options that nvim-jdtls generates such that built-in Java objects will never be stepped-into. This change makes sense for almost all developers who are using the java debugger, the only exception being if they are developing the JDK classes themselves.

This option can be overridden with the `config_overrides` value in each respective functions.