### PR TITLE
traverse children of lenses to show individual methods

### DIFF
--- a/lua/jdtls/dap.lua
+++ b/lua/jdtls/dap.lua
@@ -454,7 +454,7 @@ function M.test_nearest_method(opts)
   end)
 end
 
-function populate_candidates(list, lenses)
+local function populate_candidates(list, lenses)
   for _, v in pairs(lenses) do
     table.insert(list,  v)
     if v.children ~= nil then

--- a/lua/jdtls/dap.lua
+++ b/lua/jdtls/dap.lua
@@ -454,6 +454,14 @@ function M.test_nearest_method(opts)
   end)
 end
 
+function populate_candidates(list, lenses)
+  for _, v in pairs(lenses) do
+    table.insert(list,  v)
+    if v.children ~= nil then
+      populate_candidates(list, v.children)
+    end
+  end
+end
 
 --- Prompt for a test method from the current buffer to run
 ---@param opts nil|JdtTestOpts
@@ -461,8 +469,11 @@ function M.pick_test(opts)
   opts = opts or {}
   local context = make_context(opts.bufnr)
   fetch_candidates(context, function(lenses)
+    local candidates = {}
+    populate_candidates(candidates, lenses)
+
     require('jdtls.ui').pick_one_async(
-      lenses,
+      candidates,
       'Tests> ',
       function(lens) return lens.fullName end,
       function(lens)


### PR DESCRIPTION
when running `:lua require'jdtls'.pick_test()` only the class is show in the choices.

I've written a method to traverse the children to expose the individual methods as well.