### PR TITLE
Add `gradlew` to the quickstart-config root detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Add the following to `~/.config/nvim/ftplugin/java.lua` (See `:help base-directo
 ```lua
 local config = {
     cmd = {'/path/to/jdt-language-server/bin/jdtls'},
-    root_dir = vim.fs.dirname(vim.fs.find({'.gradlew', '.git', 'mvnw'}, { upward = true })[1]),
+    root_dir = vim.fs.dirname(vim.fs.find({'gradlew', '.git', 'mvnw'}, { upward = true })[1]),
 }
 require('jdtls').start_or_attach(config)
 ```


### PR DESCRIPTION
Gradle projects do not always have a `.git` and
commonly use a `gradlew` instead of a (aleready detected) `.gradlew`.