### PR TITLE
Fix mem example config in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ local config = {
     '-Declipse.product=org.eclipse.jdt.ls.core.product',
     '-Dlog.protocol=true',
     '-Dlog.level=ALL',
-    '-Xms1g',
+    '-Xmx1g',
     '--add-modules=ALL-SYSTEM',
     '--add-opens', 'java.base/java.util=ALL-UNNAMED',
     '--add-opens', 'java.base/java.lang=ALL-UNNAMED',


### PR DESCRIPTION
The official examples on eclipse.jdt.ls all use `-Xmx1G` (max 1GB):

* https://github.com/eclipse/eclipse.jdt.ls/blob/master/README.md#running-from-the-command-line
* https://github.com/eclipse/eclipse.jdt.ls/wiki/Running-the-JAVA-LS-server-from-the-command-line#running-the-java-ls-server

Not sure why this was changed to `-Xms1G` (**min** 1GB). Changing this reduced the memory footprint from > 1GB to ~350MB for me.