### PR TITLE
Remove config.cmd executable check

### DIFF
--- a/lua/jdtls/setup.lua
+++ b/lua/jdtls/setup.lua
@@ -214,10 +214,6 @@ function M.start_or_attach(config)
     'Config must have a `cmd` property and that must be a table. Got: '
       .. table.concat(config.cmd, ' ')
   )
-  assert(
-    tonumber(vim.fn.executable(config.cmd[1])) == 1,
-    'LSP cmd must be an executable: ' .. config.cmd[1]
-  )
   config.name = 'jdtls'
 
   local bufnr = api.nvim_get_current_buf()


### PR DESCRIPTION
Apparently it doesn't work right on windows:

https://github.com/mfussenegger/nvim-jdtls/issues/479

The check is redundant anyway, because the built-in client will fail
with a good error message since:

https://github.com/neovim/neovim/commit/1a60580925865445efbe476931dd02ef1a3a8e7f
