### PR TITLE
fix: unable get expected altbuf

### DIFF
--- a/plugin/nvim_jdtls.vim
+++ b/plugin/nvim_jdtls.vim
@@ -7,3 +7,8 @@ au BufReadCmd jdt://* lua require('jdtls').open_classfile(vim.fn.expand('<amatch
 au BufReadCmd *.class lua require("jdtls").open_classfile(vim.fn.expand("<amatch>"))
 command! JdtWipeDataAndRestart lua require('jdtls.setup').wipe_data_and_restart()
 command! JdtShowLogs lua require('jdtls.setup').show_logs()
+
+augroup record_latest_jdtls_buf
+  autocmd!
+  au BufEnter * lua require("jdtls.setup").record_latest_jdtls_buf()
+augroup end


### PR DESCRIPTION
In commit 365811ecf97a08d0e2055fba210d65017344fd15, we inferred the altbuf. However, there are two issues:

1. `bufnr([{buf} [, {create}]])` - The second parameter 'create' in `bufnr([{buf} [, {create}]])` cannot be set to a value, as it will create a new buffer when no previous buffer exists.
2. When I execute `lsp_util.locations_to_items` in the `jdt://` buffer, other `jdt://` locations will be parsed. However, at this point, I cannot retrieve the previous buffer using `bufnr('#')`. The return value will be `-1`.

Therefore, I want to manage the latest accessed buffer associated with jdtls. I will record the latest buffer at `on_attach` and `BufEnter`.