### PR TITLE
Truncate status messages instead of triggering "Press ENTER" prompt

### DIFF
--- a/lua/jdtls/setup.lua
+++ b/lua/jdtls/setup.lua
@@ -7,7 +7,8 @@ local URI_SCHEME_PATTERN = '^([a-zA-Z]+[a-zA-Z0-9+-.]*)://.*'
 
 
 local status_callback = function(_, result)
-  api.nvim_command(string.format(':echohl Function | echo "%s" | echohl None', result.message))
+  api.nvim_command(string.format(':echohl Function | echo "%s" | echohl None',
+                                string.sub(result.message, 1, vim.v.echospace)))
 end
 
 


### PR DESCRIPTION
The behavior described in #207 occurs for me when the URLs of dependencies being downloaded are too long to fit on one line (because my config has`cmdheight=1`). A workaround is to adjust `cmdheight` to a number of lines that gives sufficient space for dependency URLs, but this is an undesirable change and the full dependency URLs are just noise.

The solution is to truncate messages whose length exceed `vim.v.echospace`.