### PR TITLE
fix restart

### DIFF
--- a/lua/jdtls/setup.lua
+++ b/lua/jdtls/setup.lua
@@ -13,7 +13,7 @@ end
 
 
 M.restart = function()
-  for _, client in lsp.get_active_clients({ name = "jdtls" }) do
+  for _, client in ipairs(lsp.get_active_clients({ name = "jdtls" })) do
     local bufs = lsp.get_buffers_by_client_id(client.id)
     client.stop()
     vim.wait(30000, function()


### PR DESCRIPTION
Fix the error when calling `:JdtRestart`

```
msg_show.lua_error   JdtRestart E5108: Error executing lua ...an/.local/share/nvim/lazy/nvim-jdtls/lua/jdtls/setup.lua:16: attempt to call a table value
stack traceback:
	...an/.local/share/nvim/lazy/nvim-jdtls/lua/jdtls/setup.lua:16: in function 'restart'
	[string ":lua"]:1: in main chunk
```