### PR TITLE
adjusted the interface of `jdtls.setup.start_or_attach`

### DIFF
--- a/lua/jdtls/setup.lua
+++ b/lua/jdtls/setup.lua
@@ -244,7 +244,7 @@ function M.start_or_attach(config, opts)
     'Config must have a `cmd` property and that must be a table. Got: '
       .. table.concat(config.cmd, ' ')
   )
-  config.name = 'jdtls'
+  config.name = config.name or 'jdtls'
   local on_attach = config.on_attach
   config.on_attach = function(client, bufnr)
     if on_attach then

--- a/lua/jdtls/setup.lua
+++ b/lua/jdtls/setup.lua
@@ -298,7 +298,7 @@ function M.start_or_attach(config, opts)
     }
   })
   maybe_implicit_save()
-  vim.lsp.start(config)
+  return vim.lsp.start(config, opts)
 end
 
 


### PR DESCRIPTION
the function `start_or_attach` has the same interface as `vim.lsp.start`
now.

this helps to embed nvim-jdtls into nvim lua configurations, that wish
to abstract over multiple different LSPs.
