### PR TITLE
Displaying err.data.cause.message if present

### DIFF
--- a/lua/jdtls/dap.lua
+++ b/lua/jdtls/dap.lua
@@ -199,7 +199,8 @@ local function fetch_candidates(context, on_candidates)
 
   local handler = function(err, result)
     if err then
-      vim.notify('Error fetching test candidates: ' .. (err.message or vim.inspect(err)), vim.log.levels.ERROR)
+      local message = vim.tbl_get(err, 'data', 'cause', 'message') or err.message
+      vim.notify('Error fetching test candidates: ' .. (message or vim.inspect(err)), vim.log.levels.ERROR)
     else
       on_candidates(result or {})
     end


### PR DESCRIPTION
While trying to run a test class I got the error `org/eclipse/jdt/ls/core/internal/hover/JavaElementLabels`. Inspecting the error object I got:

```lua
{
  code = -32001,
  data = {
    cause = {
      message = "org.eclipse.jdt.ls.core.internal.hover.JavaElementLabels cannot be found by com.microsoft.java.test.plugin_0.39.1"
    },
    message = "org/eclipse/jdt/ls/core/internal/hover/JavaElementLabels"
  },
  message = "org/eclipse/jdt/ls/core/internal/hover/JavaElementLabels",
 }
```

I think what's in `data.cause.message` is more useful.