### PR TITLE
Add bufnr to open_classfile

### DIFF
--- a/doc/jdtls.txt
+++ b/doc/jdtls.txt
@@ -149,7 +149,7 @@ M.jol({mode?}, {classname?})                                         *jdtls.jol*
         {classname?}  (string)  fully qualified class name. Defaults to the current class.
 
 
-M.open_classfile({fname})                                 *jdtls.open_classfile*
+M.open_classfile({fname}, {opts?})                        *jdtls.open_classfile*
      Open `jdt://` uri or decompile class contents and load them into the buffer
 
      nvim-jdtls by defaults configures a `BufReadCmd` event which uses this function.
@@ -158,6 +158,9 @@ M.open_classfile({fname})                                 *jdtls.open_classfile*
 
     Parameters: ~
         {fname}  (string)
+	{opts?}  ({ bufnr: integer })
+		 • *bufnr*: the buffer to which the decompiled class contents
+		 needs to be filled. Defaults to current buffer if not provided.
 
 
 M.set_runtime({runtime})                                     *jdtls.set_runtime*

--- a/lua/jdtls.lua
+++ b/lua/jdtls.lua
@@ -1160,7 +1160,9 @@ end
 --- You shouldn't need to call this manually.
 ---
 ---@param fname string
-function M.open_classfile(fname)
+---@param opts? { bufnr: integer }
+function M.open_classfile(fname, opts)
+  opts = opts or {}
   local uri
   local use_cmd
   if vim.startswith(fname, "jdt://") then
@@ -1173,7 +1175,7 @@ function M.open_classfile(fname)
       return
     end
   end
-  local buf = api.nvim_get_current_buf()
+  local buf = opts.bufnr or api.nvim_get_current_buf()
   vim.bo[buf].modifiable = true
   vim.bo[buf].swapfile = false
   vim.bo[buf].buftype = 'nofile'


### PR DESCRIPTION
Hi,
This adds an optional parameter in the function `open_classfile`, to show decompiled class files to another buffer 
As per the docs, there is no need to call this function manually, but there are a few cases where we might need to do so. An example is a custom previewer in `telescope` where the current buffer and the preview buffer are not the same.
usage:
```lua
require("jdtls").open_classfile(filename, { bufnr = bufnr })
```