### PR TITLE
Non project files caused setup_dap_main_class_configs to fail

### DIFF
--- a/lua/jdtls/dap.lua
+++ b/lua/jdtls/dap.lua
@@ -602,6 +602,10 @@ function M.fetch_main_configs(opts, callback)
   util.execute_command({command = 'vscode.java.resolveMainClass'}, function(err, mainclasses)
     assert(not err, vim.inspect(err))
 
+    mainclasses = vim.tbl_filter(function(mc)
+      return mc.mainClass and mc.projectName
+    end, mainclasses)
+
     local remaining = #mainclasses
     if remaining == 0 then
       callback(configurations)


### PR DESCRIPTION
`vscode.java.resolveMainClass` returns ResolutionItems without `projectName` for non project classes. Thus, calls to
`vscode.java.resolveJavaExecutable` resulted in "Index 1 out of bounds for length 1". This cascaded into `vscode.java.resolveClasspath` failing with "Failed to resolve classpath: Referenced classpath provider does not exist: org.eclipse.m2e.launchconfig.classpathProvider".