### PR TITLE
Update README.md RE `nvim-dap` configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,7 +326,9 @@ config['init_options'] = {
 ### nvim-dap setup
 
 `nvim-jdtls` will automatically register a `java` debug adapter with nvim-dap,
-if nvim-dap is available.
+if nvim-dap is available. For this to happen, nvim-dap needs to be loaded *before*
+`nvim-jdtls`. Use the appropriate option in your package manager (i.e.
+`dependencies` for `Lazy`, `requires` for `packer`).
 
 
 ### nvim-dap configuration


### PR DESCRIPTION
I was having issues getting my DAP integration working, and I think it was because `nvim-jdtls` was loading before `nvim-dap` was finished... I'm not sure if this is actually the case, but adding `dependencies='mfussenger/nvim-dap'` to my Lazy configuration for `nvim-jdtls` has seemed to fix the issue.

Please verify whether it's possible that this was the issue. If so, then it would be a good idea to add this to https://github.com/mfussenegger/nvim-dap/wiki/Java as well.