### PR TITLE
Relax client attach condition and allow any buftype again

### DIFF
--- a/lua/jdtls/setup.lua
+++ b/lua/jdtls/setup.lua
@@ -295,7 +295,7 @@ function M.start_or_attach(config, opts, start_opts)
 
   local uri = vim.uri_from_bufnr(bufnr)
   -- jdtls requires files to exist on the filesystem; it doesn't play well with scratch buffers
-  if not vim.startswith(uri, "file://") or vim.bo[bufnr].buftype ~= "" then
+  if not vim.startswith(uri, "file://") then
     return
   end
 


### PR DESCRIPTION
Restricting buftype to "" broke support for opening .class files
