### PR TITLE
Set empty diagnostics on code action params

### DIFF
--- a/lua/jdtls.lua
+++ b/lua/jdtls.lua
@@ -840,11 +840,16 @@ end
 
 
 local function make_code_action_params(from_selection)
+  local params
   if from_selection then
-    return vim.lsp.util.make_given_range_params()
+    params = vim.lsp.util.make_given_range_params()
   else
-    return vim.lsp.util.make_range_params()
+    params = vim.lsp.util.make_range_params()
   end
+  params.context = {
+    diagnostics = {}
+  }
+  return params
 end
 
 


### PR DESCRIPTION
Follow up to 6e99fc8076d186cf1ebb1a34b4f521a66fd9a87f

The diagnostics are not nullable:

- https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#codeActionContext
