### PR TITLE
feat: add raw test results to after_test callback

### DIFF
--- a/lua/jdtls/dap.lua
+++ b/lua/jdtls/dap.lua
@@ -482,10 +482,10 @@ local function run(lens, config, context, opts)
         server:shutdown()
         server:close()
       end
-      local items = test_results.show(lens)
+      local items, tests = test_results.show(lens)
       maybe_repeat(lens, config, context, opts, items)
       if opts.after_test then
-        opts.after_test(items)
+        opts.after_test(items, tests)
       end
     end;
   })

--- a/lua/jdtls/junit.lua
+++ b/lua/jdtls/junit.lua
@@ -234,7 +234,7 @@ function M.mk_test_results(bufnr)
       else
         print('Tests finished. Results printed to dap-repl.', success_symbol, #tests, 'succeeded')
       end
-      return items
+      return items, tests
     end,
     mk_reader = function(sock)
       return vim.schedule_wrap(mk_buf_loop(sock, handle_buffer))


### PR DESCRIPTION
I would like to do things depending on whether or not tests failed. It looks like after_test was made for this purposeq, but the items passed to it currently is often an empty array. I would like to be able to get the original parsed test results