### PR TITLE
Provide flexibility to use different quickfix UIs in Build and Compile Actions.

### DIFF
--- a/doc/jdtls.txt
+++ b/doc/jdtls.txt
@@ -26,6 +26,7 @@ M.compile({type})                                                *jdtls.compile*
     Parameters: ~
         {type}  (string|nil)  |"full"
                               |"incremental"
+	{on_compile_result?}  (fun(result: table[]): nil)  Callback to be called when the compile result is received.
 
 
 M.build_projects({opts})                                  *jdtls.build_projects*
@@ -41,6 +42,7 @@ JdtBuildProjectOpts                                        *JdtBuildProjectOpts*
     Fields: ~
         {select_mode?}  (JdtProjectSelectMode)  Show prompt to select projects or select all. Defaults to "prompt"
         {full_build?}   (boolean)               full rebuild or incremental build. Defaults to true (full build)
+	{on_compile_result?}  (fun(result: table[]): nil)  Callback to be called when the compile result is received.
 
 
 M.update_project_config()                          *jdtls.update_project_config*


### PR DESCRIPTION
This PR introduces a new optional option`quickfix_open_cmd` for the `compile` and `build`. This allows users to specify a custom command for opening the quickfix list. If not provided, the default behavior (`copen`) remains unchanged, ensuring backward compatibility.

The added option enables seamless integration with plugins that offer enhanced quickfix UIs, such as [Trouble.nvim](https://github.com/folke/trouble.nvim), providing a more customizable user experience for error navigation.

Please let me know if this change aligns with the project's vision and if it can be integrated.

Thank you for creating and maintaining this amazing plugin; it has significantly enhanced my workflow!