### PR TITLE
fix: When test throws an exception, stacktrace shown in dap repl is truncated 

### DIFF
--- a/lua/jdtls/junit.lua
+++ b/lua/jdtls/junit.lua
@@ -129,7 +129,7 @@ function M.mk_test_results(bufnr)
           local testMatch
           for _, msg in ipairs(test.traces) do
             local match = msg:match(string.format('at %s.%s', test.fq_class, test.method) .. '%(([%w%p]*:%d+)%)')
-            if match then
+            if ((not testMatch) and match) then
               testMatch = true
               local lnum = vim.split(match, ':')[2]
               local trace = table.concat(test.traces, '\n')
@@ -150,7 +150,6 @@ function M.mk_test_results(bufnr)
                 source = 'junit',
                 message = cause,
               })
-              break
             end
             repl.append(msg, '$')
           end


### PR DESCRIPTION
basic fix of https://github.com/mfussenegger/nvim-jdtls/issues/736

@vishal423 Could you please look at it as well? It mainly involves your changes. 
I have to admit, that I don't get every line here. I wouldn't like to break something. 

@mfussenegger @vishal423  I'd like to thank you for your work! I really appreciate it.



