### PR TITLE
Add way to generate main->test code mapping via coverage & show affected

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -1,12 +1,13 @@
 {
   "$schema": "https://raw.githubusercontent.com/LuaLS/vscode-lua/master/setting/schema.json",
   "runtime": {
-    "version": "LuaJIT"
+    "version": "LuaJIT",
+    "pathStrict": true
   },
   "workspace": {
     "library": [
       "lua",
-      "$VIMRUNTIME",
+      "$VIMRUNTIME/lua",
       "${3rd}/luv/library",
       "${3rd}/busted/library",
       "${3rd}/luassert/library"

--- a/lua/jdtls/async.lua
+++ b/lua/jdtls/async.lua
@@ -1,0 +1,48 @@
+local M = {}
+
+
+--- Runs the given function in a coroutine, shows uncaught errors using vim.notify
+---
+---@param fn function
+function M.run(fn)
+  local co, is_main = coroutine.running()
+  if co and not is_main then
+    fn()
+  else
+    coroutine.wrap(function()
+      xpcall(fn, function(err)
+        local msg = debug.traceback(err, 2)
+        vim.notify(msg, vim.log.levels.ERROR)
+      end)
+    end)()
+  end
+end
+
+
+--- Create a callback function that resumes the given coroutine
+--- or the coroutine that was running when called
+---
+---@param co thread?
+function M.resumecb(co)
+  if not co then
+    local current_co, is_main = coroutine.running()
+    assert(current_co and not is_main, "resumecb must be called within a coroutine")
+    co = current_co
+  end
+  return function(...)
+    if coroutine.status(co) == "suspended" then
+      coroutine.resume(co, ...)
+    else
+      local args = {...}
+      vim.schedule(function()
+        assert(
+          coroutine.status(co) == "suspended",
+          "Illegal use of resumecb(), Callee must have yielded")
+        coroutine.resume(co, unpack(args))
+      end)
+    end
+  end
+end
+
+
+return M

--- a/lua/jdtls/coverage.lua
+++ b/lua/jdtls/coverage.lua
@@ -1,0 +1,192 @@
+local M = {}
+local async = require("jdtls.async")
+local api = vim.api
+
+---@class jdtls.coverage.CoverageResult
+---@field lineCoverages jdtls.coverage.LineCoverage[]
+---@field methodCoverages jdtls.coverage.MethodCoverage[]
+---@field uriString string
+
+---@class jdtls.coverage.LineCoverage
+---@field branchCoverages table
+---@field hit integer
+---@field lineNumber integer
+
+---@class jdtls.coverage.MethodCoverage
+---@field hit integer
+---@field lineNumber integer
+---@field name string
+
+---@param bufnr integer
+---@param msg string|string[]
+local function append(bufnr, msg)
+  if type(msg) ~= "table" then
+    msg = { msg }
+  end
+  api.nvim_buf_set_lines(bufnr, -1, -1, true, msg)
+  vim.bo[bufnr].modified = false
+end
+
+
+local function create_impact_map()
+  assert(coroutine.running(), "Must run in coroutine")
+  ---@type vim.lsp.Client
+  local client = assert(vim.lsp.get_clients({ name = "jdtls" })[1], "Must have jdtls client running")
+  local win = api.nvim_get_current_win()
+  local bufnr = api.nvim_get_current_buf()
+  vim.cmd.new()
+  local progressbuf = api.nvim_get_current_buf()
+  api.nvim_buf_set_name(progressbuf, "jdtls-coverage-progress://" .. progressbuf)
+  api.nvim_win_set_buf(win, bufnr)
+  append(
+    progressbuf,
+    {
+      "Starting coverage data generation. This may take some time.",
+      "Deleting this buffer will interrupt the operation",
+      ""
+    }
+  )
+  local cmd_context = { bufnr = bufnr }
+
+  local find_projects = {
+    command = "vscode.java.test.findJavaProjects",
+    arguments = { vim.uri_from_fname(client.config.root_dir) }
+  }
+  local resume = async.resumecb()
+  client:exec_cmd(find_projects, cmd_context, resume)
+  local err, projects = coroutine.yield()
+  assert(not err, err)
+
+  local coverage_map = {}
+  for i, project in ipairs(projects or {}) do
+    local find_tests = {
+      command = "vscode.java.test.findTestPackagesAndTypes",
+      arguments = { project.jdtHandler }
+    }
+    local tests
+    client:exec_cmd(find_tests, cmd_context, resume)
+    err, tests = coroutine.yield()
+    if err then
+      vim.notify(vim.inspect(err), vim.log.levels.ERROR)
+    end
+    assert(not err, err)
+
+    local all_tests = {}
+    for _, pkg in ipairs(tests) do
+      for _, child in ipairs(pkg.children) do
+        table.insert(all_tests, child)
+      end
+    end
+    local msg = string.format("Found %d tests in %s. Generating coverage data ...", #all_tests, project.projectName)
+    if i > 1 then
+      append(progressbuf, "")
+    end
+    append(progressbuf, msg)
+
+
+    ---@type lsp.Command
+    local get_coverage = {
+      title = "getCoverageDetail",
+      command = "vscode.java.test.jacoco.getCoverageDetail",
+      arguments = {
+        project.projectName,
+        "<unknown-basepath>", -- set below
+      }
+    }
+
+    local coverage
+    for _, test in ipairs(all_tests) do
+      if not api.nvim_buf_is_valid(progressbuf) then
+        vim.notify(
+          "Progress monitoring buffer disappeared, aborting coverage data generation",
+          vim.log.levels.WARN
+        )
+        return
+      end
+
+      append(progressbuf, "Running " .. test.fullName)
+      local testbuf = vim.uri_to_bufnr(test.uri)
+      vim.fn.bufload(testbuf)
+      vim.lsp.buf_attach_client(testbuf, client.id)
+
+      require("jdtls.dap").create_class_coverage({ bufnr = testbuf }, resume)
+      local basepath = coroutine.yield()
+      if basepath then
+        get_coverage.arguments[2] = basepath .. "/target"
+
+        client:exec_cmd(get_coverage, cmd_context, resume)
+        err, coverage = coroutine.yield()
+        if err then
+          vim.notify(vim.inspect(err), vim.log.levels.ERROR)
+        end
+
+        assert(not err, err)
+        ---@cast coverage jdtls.coverage.CoverageResult[]
+        for _, cov in ipairs(assert(coverage)) do
+          local uri = vim.uri_from_fname(cov.uriString:sub(#"file:/"))
+          local covering_tests = coverage_map[uri]
+          if not covering_tests then
+            covering_tests = {}
+            coverage_map[uri] = covering_tests
+          end
+          local total_hits = 0
+          for _, method_cov in ipairs(cov.methodCoverages) do
+            total_hits = total_hits + method_cov.hit
+          end
+          if total_hits > 0 then
+            table.insert(covering_tests, test.uri)
+          end
+        end
+      end
+    end
+  end
+
+  append(progressbuf, "Coverage data generation finished")
+  local coverage_json = vim.json.encode(coverage_map)
+  local f = io.open("/tmp/coverage.json", "w+")
+  if f then
+    f:write(coverage_json)
+    f:close()
+  end
+end
+
+
+--- Creates coverage data and generates a map from covered files to test suites
+---
+--- This will run all test suites sequentially and can take a long time
+function M.create_impact_map()
+  async.run(create_impact_map)
+end
+
+
+function M.test_impacted()
+end
+
+function M.get_impacted()
+  local f = io.open("/tmp/coverage.json", "r")
+  if not f then
+    error("no coverage data found")
+  end
+  local content = f:read("*a")
+  local coverage = vim.json.decode(content)
+  local result = vim.system({"git", "status", "--porcelain"}, { text = true }):wait()
+  local impacted = {}
+  for line in vim.gsplit(result.stdout, "\n", { plain = true }) do
+    if vim.startswith(line, " M ") then
+      line = line:sub(4)
+    end
+    local fname = line
+    local uri = vim.uri_from_fname(vim.fn.fnamemodify(fname, ":p"))
+    local impacted_tests = coverage[uri]
+    if impacted_tests then
+      for _, test in ipairs(impacted_tests) do
+        local path = vim.fn.fnamemodify(vim.uri_to_fname(test), ":.")
+        impacted[path] = true
+      end
+    end
+  end
+  return vim.tbl_keys(impacted)
+end
+
+
+return M

--- a/lua/jdtls/junit.lua
+++ b/lua/jdtls/junit.lua
@@ -203,21 +203,26 @@ function M.mk_test_results(bufnr)
       local unique_lnums = {}
       -- Traverse in reverse order to preserve the mark position in case of Repeated/Parameterized Tests
       -- right_align doesn't seems to work correctly when set to false
+      local setextmark = vim.api.nvim_buf_is_loaded(bufnr)
       for i = #results, 1, -1 do
         local result = results[i]
         local symbol = result.success and success_symbol or error_symbol
-        vim.api.nvim_buf_set_extmark(bufnr, ns, result.lnum, 0, {
-          virt_text = { { symbol } },
-          invalidate = true
-        })
+        if setextmark then
+          vim.api.nvim_buf_set_extmark(bufnr, ns, result.lnum, 0, {
+            virt_text = { { symbol } },
+            invalidate = true
+          })
+        end
         unique_lnums[result.lnum] = true
       end
       for key, _ in pairs(unique_lnums) do
         local indent = '\t'
-        vim.api.nvim_buf_set_extmark(bufnr, ns, key, 0, {
-          virt_text = { { indent } },
-          invalidate = true
-        })
+        if setextmark then
+          vim.api.nvim_buf_set_extmark(bufnr, ns, key, 0, {
+            virt_text = { { indent } },
+            invalidate = true
+          })
+      end
       end
 
       if num_failures > 0 then

--- a/lua/jdtls/tests.lua
+++ b/lua/jdtls/tests.lua
@@ -4,6 +4,7 @@
 local api = vim.api
 local M = {}
 
+
 --- Generate tests for the current class
 --- @param opts? {bufnr: integer}
 function M.generate(opts)

--- a/lua/jdtls/util.lua
+++ b/lua/jdtls/util.lua
@@ -8,6 +8,9 @@ local get_clients = vim.lsp.get_clients or vim.lsp.get_active_clients
 function M.execute_command(command, callback, bufnr)
   local clients = {}
   local candidates = get_clients({ bufnr = bufnr })
+  if not next(candidates) then
+    candidates = get_clients({ name = "jdtls" })
+  end
   for _, c in pairs(candidates) do
     local command_provider = c.server_capabilities.executeCommandProvider
     local commands = type(command_provider) == 'table' and command_provider.commands or {}
@@ -17,13 +20,8 @@ function M.execute_command(command, callback, bufnr)
   end
   local num_clients = vim.tbl_count(clients)
   if num_clients == 0 then
-    if bufnr then
-      -- User could've switched buffer to non-java file, try all clients
-      return M.execute_command(command, callback, nil)
-    else
-      vim.notify('No LSP client found that supports ' .. command.command, vim.log.levels.ERROR)
-      return
-    end
+    vim.notify('No LSP client found that supports ' .. command.command, vim.log.levels.ERROR)
+    return
   end
 
   if num_clients > 1 then
@@ -61,7 +59,7 @@ function M.with_java_executable(mainclass, project, fn, bufnr)
 
   local client = get_clients({ name = "jdtls", bufnr = bufnr, method = "workspace/executeCommand" })[1]
   if not client then
-    print("No jdtls client found")
+    vim.notify("No jdtls client found for bufnr=" .. bufnr, vim.log.levels.INFO)
     return
   end
 
@@ -112,7 +110,7 @@ end
 function M.with_classpaths(fn)
   local bufnr = api.nvim_get_current_buf()
   local uri = vim.uri_from_bufnr(bufnr)
-  coroutine.wrap(function()
+  require("jdtls.async").run(function()
     local is_test_file_cmd = {
       command = 'java.project.isTestFile',
       arguments = { uri }
@@ -137,7 +135,7 @@ function M.with_classpaths(fn)
     else
       fn(resp)
     end
-  end)()
+  end)
 end
 
 


### PR DESCRIPTION
Allows to generate a coverage mapping from main code to test code by
running each test suite one after another, each time processing the
generated coverage data.

After that the coverage data can be combined with a git diff to see
which tests are most likely to be affected.

Not bullet proof, but can in many cases safe the time to run the full
test suite, reducing the feedback loop.
