### PR TITLE
Call `Client.request` using colon operator

### DIFF
--- a/lua/jdtls/util.lua
+++ b/lua/jdtls/util.lua
@@ -53,7 +53,7 @@ function M.execute_command(command, callback, bufnr)
       end
     end
   end
-  clients[1].request('workspace/executeCommand', command, callback, bufnr)
+  clients[1]:request('workspace/executeCommand', command, callback, bufnr)
   if co then
     return coroutine.yield()
   end


### PR DESCRIPTION
This fixes DAP integration.

Steps to reproduce without this patch:
1. Launch a java project
2. Try to launch DAP on an open file
3. See nvim-jdtls fail with:
```
/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:291: Cannot serialise function: type not supported
stack traceback:
^I[C]: in function 'encode'
^I/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:291: in function 'encode_and_send'
^I/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:338: in function 'request'
^I/usr/share/nvim/runtime/lua/vim/lsp/client.lua:679: in function 'request'
^I.../.local/share/nvim/lazy/nvim-jdtls/lua/jdtls/util.lua:56: in function 'execute_command'
^I.../.local/share/nvim/lazy/nvim-jdtls/lua/jdtls/dap.lua:93: in function 'adapter'
^I.local/share/nvim/lazy/nvim-dap/lua/dap.lua:627: in function <.local/share/nvim/lazy/nvim-dap/lua/dap.lua:613>
^I[C]: in function 'xpcall'
^I.../.local/share/nvim/lazy/nvim-dap/lua/dap/async.lua:12: in function <.../.local/share/nvim/lazy/nvim-dap/lua/dap/async.lua:11>
```

The problem seems to be calling [Client.request()](https://neovim.io/doc/user/lsp.html#Client%3Arequest()) using the `.` operator instead of the `:` operator. This will not pass `self` to the function, causing argument to shift one position to the left and leading to a crash due to misalagnment of parameters. In this specific case I believe `callback` is being treated as `command` leading to serialisation error.