### PR TITLE
fix(set-runtime): do not expect config to always have .settings

### DIFF
--- a/lua/jdtls.lua
+++ b/lua/jdtls.lua
@@ -1267,7 +1267,7 @@ end
 ---@private
 function M._complete_set_runtime()
   local client
-  for _, c in pairs(util.get_clients()) do
+  for _, c in pairs(util.get_clients({name = "jdtls"})) do
     if c.config.settings.java then
       client = c
       break
@@ -1286,7 +1286,7 @@ end
 ---@param runtime nil|string Java runtime. Prompts for runtime if nil
 function M.set_runtime(runtime)
   local client
-  for _, c in pairs(util.get_clients()) do
+  for _, c in pairs(util.get_clients({name = "jdtls"})) do
     if c.config.settings.java then
       client = c
       break


### PR DESCRIPTION
Some clients (notably null-ls) do not set config.settings to anything, leading to config.settings.java failing with "attempt to index on nil" error.

Can also check explicitly for that but figured we only care about jdtls anyway.