### PR TITLE
Add support to run project

### DIFF
--- a/lua/jdtls/dap.lua
+++ b/lua/jdtls/dap.lua
@@ -751,6 +751,10 @@ function M.setup_dap(opts)
       M.fetch_main_configs(nil, function(configs)
         if not resumed then
           resumed = true
+          local noDebug = vim.fn.input("noDebug? ") == 't' and true or false
+          for _, v in ipairs(configs) do
+            v.noDebug = noDebug
+          end
           coroutine.resume(co, configs)
         end
       end)


### PR DESCRIPTION
Add user input ('t') to toggle between running and debugging the project.