### PR TITLE
Allow test symbols to be configured by the user

### DIFF
--- a/lua/jdtls.lua
+++ b/lua/jdtls.lua
@@ -34,6 +34,9 @@ local M = {
 ---@param start_opts? vim.lsp.start.Opts options passed to vim.lsp.start
 ---@return integer|nil client_id
 function M.start_or_attach(config, opts, start_opts)
+  if config.tests then
+    require('jdtls.junit').setup(config.tests)
+  end
   return setup.start_or_attach(config, opts, start_opts)
 end
 


### PR DESCRIPTION
Hi @mfussenegger,
first of all thanks for this great plugin, it's been my daily driver for over three years.
The font I use does not have the hard coded symbols for test success/failure, so I've added the option to pass them in through config. Let me know if you spot any improvements.