### PR TITLE
Fix first line in doc for local-additions

### DIFF
--- a/doc/jdtls.txt
+++ b/doc/jdtls.txt
@@ -1,5 +1,5 @@
+*jdtls*                             LSP extensions for Neovim and eclipse.jdt.ls
 ==============================================================================
-LSP extensions for Neovim and eclipse.jdt.ls                             *jdtls*
 
                                                          *jdtls.start_or_attach*
 M.start_or_attach({config}, {opts?}, {start_opts?})


### PR DESCRIPTION
The documentation for vim help pages states that a first line is required for the file to appear under `:help local-additions`, with the following format: `*tag* description`

This change moves line 2 to the beginning and adapts to such format