### PR TITLE
Port class file handlers from Vimscript to Lua

### DIFF
--- a/plugin/nvim_jdtls.lua
+++ b/plugin/nvim_jdtls.lua
@@ -1,0 +1,55 @@
+if vim.g.nvim_jdtls then
+  return
+end
+vim.g.nvim_jdtls = 1
+
+vim.api.nvim_create_user_command("JdtWipeDataAndRestart", function()
+  require("jdtls.setup").wipe_data_and_restart()
+end, {})
+
+vim.api.nvim_create_user_command("JdtShowLogs", function()
+  require("jdtls.setup").show_logs()
+end, {})
+
+local jdtls_handler_group = vim.api.nvim_create_augroup("JdtlsHandlers", { clear = true })
+
+local function register_handlers()
+  vim.api.nvim_clear_autocmds({ group = jdtls_handler_group })
+
+  local function handle_class_file(path)
+    local success, result = pcall(require("jdtls").open_classfile, path)
+    if not success then
+      return false
+    end
+    return result
+  end
+
+  local patterns = {
+    "jdt://*",
+    "*.class",
+  }
+
+  for _, pattern in ipairs(patterns) do
+    vim.api.nvim_create_autocmd("BufReadCmd", {
+      pattern = pattern,
+      group = jdtls_handler_group,
+      callback = function()
+        local path = vim.fn.expand("<amatch>")
+        return handle_class_file(path)
+      end,
+    })
+  end
+end
+
+local filetype_group = vim.api.nvim_create_augroup("JavaFiletypeHandlers", { clear = true })
+vim.api.nvim_create_autocmd("FileType", {
+  pattern = "java",
+  group = filetype_group,
+  callback = function()
+    register_handlers()
+  end,
+})
+
+if vim.bo.filetype == "java" then
+  register_handlers()
+end

--- a/plugin/nvim_jdtls.vim
+++ b/plugin/nvim_jdtls.vim
@@ -1,9 +1,0 @@
-if exists('g:nvim_jdtls')
-  finish
-endif
-let g:nvim_jdtls = 1
-
-au BufReadCmd jdt://* lua require('jdtls').open_classfile(vim.fn.expand('<amatch>'))
-au BufReadCmd *.class lua require("jdtls").open_classfile(vim.fn.expand("<amatch>"))
-command! JdtWipeDataAndRestart lua require('jdtls.setup').wipe_data_and_restart()
-command! JdtShowLogs lua require('jdtls.setup').show_logs()


### PR DESCRIPTION
## Problem

The current Vimscript implementation of JDTLS class file handlers registers global autocmds for patterns like `*.class`. This causes errors when navigating Kotlin projects because the handlers attempt to use JDTLS even when it's not available:

`Error: "Must have a `jdtls` client to load class file or jdt uri"`

## Solution

This MR ports the JDTLS class file handlers from Vimscript to Lua with proper filetype scoping.

## Implementation details

- Converted Vimscript autocmds to use Lua's `nvim_create_autocmd` API
- Added filetype-specific registration that only activates in Java files
- Implemented proper error handling with `pcall`
- Used return values to allow handler chaining when JDTLS isn't available
- Organized code with proper autocmd groups

Let me know if this is something you want to add to the project, or if I am missing something.

Thanks for this plugin 🙏 
