### PR TITLE
Check for `python3` executable, if not present, fallback to `python`

### DIFF
--- a/lua/jdtls/setup.lua
+++ b/lua/jdtls/setup.lua
@@ -124,7 +124,7 @@ end
 ---@return string
 local function sha1(val)
   local cmd = {
-    "python",
+    vim.fn.executable("python3") and "python3" or "python",
     "-c",
     string.format("from hashlib import sha1; print(sha1(b'%s').hexdigest())", val)
   }

--- a/lua/jdtls/setup.lua
+++ b/lua/jdtls/setup.lua
@@ -124,7 +124,7 @@ end
 ---@return string
 local function sha1(val)
   local cmd = {
-    vim.fn.executable("python3") and "python3" or "python",
+    vim.fn.executable("python3") == 1 and "python3" or "python",
     "-c",
     string.format("from hashlib import sha1; print(sha1(b'%s').hexdigest())", val)
   }


### PR DESCRIPTION
It is quite common for `python3` to be the executable instead of `python` in various platforms so add a small check here to cover that.