### PR TITLE
fix: ensure bufnr is set when starting LSP client

### DIFF
--- a/lua/jdtls/setup.lua
+++ b/lua/jdtls/setup.lua
@@ -313,6 +313,7 @@ function M.start_or_attach(config, opts, start_opts)
   end
 
   local bufnr = api.nvim_get_current_buf()
+  start_opts = vim.tbl_extend('force', { bufnr = bufnr }, start_opts or {})
   local bufname = api.nvim_buf_get_name(bufnr)
   local uri = vim.uri_from_bufnr(bufnr)
   -- jdtls requires files to exist on the filesystem; it doesn't play well with scratch buffers


### PR DESCRIPTION
Hey :wave: 

I stumbled on this issue: If `start_opts.bufnr` is unset when calling `start_or_attach`, there's a chance that the LSP client will attach to a different buffer (at least that's what I think could be happening).

I don't know how to reproduce this reliably, but I've been getting weird error messages in a large repo and calling `require('jdtls').start_or_attach(config, nil, { bufnr = bufnr })` seems to fix it for me.